### PR TITLE
Hack:  Trap nil res.Row and raise an error so higher layers can retry.

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -672,6 +672,12 @@ func (t *Table) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadMod
 	if err != nil {
 		return nil, err
 	}
+	if res == nil {
+		return nil, fmt.Errorf("unable to apply ReadModifyWrite: res=%v", res)
+	}
+	if res.Row == nil {
+		return nil, fmt.Errorf("unable to apply ReadModifyWrite: res.Row=%v", res.Row)
+	}
 	r := make(Row)
 	for _, fam := range res.Row.Families { // res is *btpb.Row, fam is *btpb.Family
 		decodeFamilyProto(r, row, fam)


### PR DESCRIPTION
This happens occasionally but regularly and w/o this hack triggers
a panic when res.Row.Families is dereferenced.  I don't think this
seems normal but haven't been able to identify the root cause.
However, retrying seems to be correct because I'm not seeing
duplicate writes after this error is caught + retried.