### PR TITLE
Return error on res.Row=nil from ApplyReadModifyWrite to avoid panic

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -672,6 +672,9 @@ func (t *Table) ApplyReadModifyWrite(ctx context.Context, row string, m *ReadMod
 	if err != nil {
 		return nil, err
 	}
+	if res.Row == nil {
+		return nil, errors.New("unable to apply ReadModifyWrite: res.Row=nil")
+	}
 	r := make(Row)
 	for _, fam := range res.Row.Families { // res is *btpb.Row, fam is *btpb.Family
 		decodeFamilyProto(r, row, fam)


### PR DESCRIPTION
Sometimes when ApplyReadModifyWrite is called it will return a
response whose res.Row is nil.  This doesn't happen frequently
but it does happen with some regularity.  I believe it's due to
a Bigtable error whose details are being lost in the empty response.
From there GRPC + ProtoBufs do their thing and end up returning
res.Row=nil.  The problem lies in the caller's assumption that if
err != nil then res.Row will not be nil, but that isn't the case
in reality and a panic ensues.

This fix changes the caller's assumptions but does not attempt to
identify the underlying error from Bigtable.  I've done some basic
experiments to show that if this error is received and then retried,
it doesn't appear to cause double-writes, but then again maybe
Bigtable will converge them later and we will end up with double-
increments in the end?  Not sure but it's beyond the scope of this fix
so I've just focused on the caller behavior.

CC @garye 
