### PR TITLE
Allow tracing across gRPC network boundaries

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -141,10 +141,12 @@ import (
 	"google.golang.org/api/support/bundler"
 	"google.golang.org/api/transport"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 const (
 	httpHeader          = `X-Cloud-Trace-Context`
+	grpcMetadataKey     = `gcloud-trace-grpc-context`
 	userAgent           = `gcloud-golang-trace/20160501`
 	cloudPlatformScope  = `https://www.googleapis.com/auth/cloud-platform`
 	spanKindClient      = `RPC_CLIENT`
@@ -214,6 +216,19 @@ var EnableGRPCTracingDialOption grpc.DialOption = grpc.WithUnaryInterceptor(grpc
 // connections.
 // The functionality in gRPC that this relies on is currently experimental.
 var EnableGRPCTracing option.ClientOption = option.WithGRPCDialOption(EnableGRPCTracingDialOption)
+
+func (client *Client) EnableGRPCServerTracing() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		span := client.SpanFromGRPCContext(ctx, info.FullMethod)
+		resp, err = handler(ctx, req)
+		if err != nil {
+			// TODO: standardize gRPC label names?
+			span.SetLabel("error", err.Error())
+		}
+		span.Finish()
+		return
+	}
+}
 
 func grpcUnaryInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	// TODO: also intercept streams.
@@ -354,6 +369,45 @@ func (client *Client) SpanFromRequest(r *http.Request) *Span {
 	return span
 }
 
+func (client *Client) SpanFromGRPCContext(ctx context.Context, name string) *Span {
+	if client == nil {
+		return nil
+	}
+	md, _ := metadata.FromContext(ctx)
+	traceID, parentSpanID, options, hasTraceHeader := traceInfoFromMetadata(md)
+	if !hasTraceHeader {
+		traceID = nextTraceID()
+	}
+	t := &trace{
+		traceID:       traceID,
+		client:        client,
+		globalOptions: options,
+		localOptions:  options,
+	}
+	span := startNewChild(name, t, parentSpanID)
+	span.span.Kind = spanKindServer
+	span.rootSpan = true
+	if client.policy != nil {
+		d := client.policy.Sample(Parameters{HasTraceHeader: hasTraceHeader})
+		if d.Trace {
+			// Turn on tracing locally, and in child requests.
+			span.trace.localOptions |= optionTrace
+			span.trace.globalOptions |= optionTrace
+		} else {
+			// Turn off tracing locally.
+			span.trace.localOptions = 0
+			return span
+		}
+		if d.Sample {
+			// This trace is in the random sample, so set the labels.
+			span.SetLabel(labelSamplingPolicy, d.Policy)
+			span.SetLabel(labelSamplingWeight, fmt.Sprint(d.Weight))
+		}
+	}
+
+	return span
+}
+
 // NewContext returns a derived context containing the span.
 func NewContext(ctx context.Context, s *Span) context.Context {
 	if s == nil {
@@ -362,15 +416,43 @@ func NewContext(ctx context.Context, s *Span) context.Context {
 	return context.WithValue(ctx, contextKey{}, s)
 }
 
+// NewGRPCContext returns a derived context compatible with gRPC
+// containing tracing information
+func NewGRPCContext(ctx context.Context, s *Span) context.Context {
+	if s == nil {
+		return ctx
+	}
+	md, _ := metadata.FromContext(ctx)
+	if md == nil {
+		md = metadata.MD{}
+	}
+	md[grpcMetadataKey] = []string{spanHeader(s.trace.traceID, s.span.ParentSpanId, s.trace.globalOptions)}
+	return metadata.NewContext(ctx, md)
+}
+
 // FromContext returns the span contained in the context, or nil.
 func FromContext(ctx context.Context) *Span {
 	s, _ := ctx.Value(contextKey{}).(*Span)
 	return s
 }
 
+func traceInfoFromMetadata(md metadata.MD) (string, uint64, optionFlags, bool) {
+	if md == nil {
+		return "", 0, 0, false
+	}
+	str, _ := md[grpcMetadataKey]
+	if len(str) == 0 {
+		return "", 0, 0, false
+	}
+	return traceInfoFromString(str[0])
+}
+
 func traceInfoFromRequest(r *http.Request) (string, uint64, optionFlags, bool) {
 	// See https://cloud.google.com/trace/docs/faq for the header format.
-	h := r.Header.Get(httpHeader)
+	return traceInfoFromString(r.Header.Get(httpHeader))
+}
+
+func traceInfoFromString(h string) (string, uint64, optionFlags, bool) {
 	// Return if the header is empty or missing, or if the header is unreasonably
 	// large, to avoid making unnecessary copies of a large string.
 	if h == "" || len(h) > 200 {


### PR DESCRIPTION
Hi there

We've had a need to trace requests through our microservices API boundaries. Currently, the existing package seems to not support this as gRPC will only propegate the Metadata block within the context.

This PR modifies the gRPC client-side interceptor so it takes the context passed in, and creates a new context with the trace information on the metadata block (by encoding the trace to a string, like the http request handler)

It then also adds a gRPC server-side interceptors that converts from the internal gRPC metadata context back into the standard context structure.

Ultimately, this means you can enable gRPC tracing on a client with:

`grpc.Dial("service:1234", trace.EnableGRPCTracingDialOption)`

and on the service with:

`grpc.NewServer(traceClient.EnableGRPCServerTracing())`

I hope this makes sense, and do let me know if you've any questions! For reference, I've attached a screenshot of a trace produced using this:

![screen shot 2016-12-02 at 17 20 41](https://cloud.githubusercontent.com/assets/203583/20843567/b51a9960-b8b3-11e6-8f6b-c87d56d4cb08.png)

As you may notice, the gRPC call is logged as two spans. This is because the first span is created on the gRPC client, and the second on the receiving gRPC server. There are a number of ways to avoid this, but I'm not sure if we *want* to avoid it.