### PR TITLE
Correct Language API Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Google API                     | Status       | Package
 [Logging][cloud-logging]       | beta         | [`cloud.google.com/go/logging`][cloud-logging-ref]
 [Pub/Sub][cloud-pubsub]        | experimental | [`cloud.google.com/go/pubsub`][cloud-pubsub-ref]
 [Vision][cloud-vision]         | experimental | [`cloud.google.com/go/vision`][cloud-vision-ref]
-[Language][cloud-language]     | experimental | [`cloud.google.com/go/language/apiv1beta1`][cloud-language-ref]
+[Language][cloud-language]     | experimental | [`cloud.google.com/go/language/apiv1`][cloud-language-ref]
 [Speech][cloud-speech]         | experimental | [`cloud.google.com/go/speech/apiv1beta`][cloud-speech-ref]
 
 


### PR DESCRIPTION
Package name in Google API list in README pointed to a non existent package. Corrected to the right one.