### PR TITLE
Fix handling of context cancel/deadline on Pub/Sub puller

### DIFF
--- a/pubsub/puller.go
+++ b/pubsub/puller.go
@@ -80,7 +80,7 @@ func (p *puller) Next() (*Message, error) {
 		for i := 0; i < maxPullAttempts; i++ {
 			// Once Stop has completed, all future calls to Next will immediately fail at this point.
 			buf, err = p.fetch()
-			if err == nil || err == context.Canceled || err == context.DeadlineExceeded {
+			if err == nil || p.ctx.Err() != nil {
 				break
 			}
 		}


### PR DESCRIPTION
This pull request fixes handling of cancellation or exceeded deadline during message fetching on the Pub/Sub puller.

The current implementation expects ``context.Canceled`` or ``context.DeadlineExceeded`` when the context is canceled or the deadline has reached. But actually, the underlying service returns ``grpc.rpcError`` wrapping those errors. Thus excessive RPC calls might occur.

This PR fixes that by checking ``context.Err()``.