### PR TITLE
Removing "application:" and "version:"

### DIFF
--- a/examples/storage/appengine/app.yaml
+++ b/examples/storage/appengine/app.yaml
@@ -1,5 +1,3 @@
-application: your-app-id
-version: v1
 runtime: go
 api_version: go1
 


### PR DESCRIPTION
To support the "gcloud app deploy" commands that all the App Engine docs now use (standard and flexible env.). This is the particular document affected:
https://cloud.google.com/appengine/docs/standard/go/googlecloudstorageclient/app-engine-cloud-storage-sample#code_walkthrough