### PR TITLE
InitialNodeCount is always zero

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -153,7 +153,7 @@ func resourceFromRaw(c *raw.Cluster) *Resource {
 		Description:       c.Description,
 		Zone:              c.Zone,
 		Status:            Status(c.Status),
-		Num:               c.InitialNodeCount,
+		Num:               c.CurrentNodeCount,
 		APIVersion:        c.InitialClusterVersion,
 		Endpoint:          c.Endpoint,
 		Username:          c.MasterAuth.Username,


### PR DESCRIPTION
The InitialNodeCount in the cluster(s) response is always zero so it is
not a useful metric to return.  The more interesting metric is the
CurrentNodeCount.  A similar argument could be made for the
InitialClusterVersion but this should be addressed in a separate commit
if it is decided that it should be changed