### PR TITLE
typo: SpamFromHeader -> SpanFromHeader

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -113,7 +113,7 @@
 //   ...
 //   childSpan.Finish(trace.WithResponse(resp))
 //
-// When a span created by SpanFromRequest or SpamFromHeader is finished, the
+// When a span created by SpanFromRequest or SpanFromHeader is finished, the
 // finished spans in the corresponding trace -- the span itself and its
 // descendants -- are uploaded to the Stackdriver Trace server using the
 // *Client that created the span.  Finish returns immediately, and uploading


### PR DESCRIPTION
corrects a typo in the descriptive commentary