### PR TITLE
checking if time is empty

### DIFF
--- a/datastore/save.go
+++ b/datastore/save.go
@@ -421,5 +421,9 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	}
+	if t, ok := v.Interface().(time.Time); ok && t.IsZero() {
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
Datastore recognize more types than "json", so when you do "omitempty", you want to skip also empty "time". I added the check.