### PR TITLE
pubsub: Fix example in package level godoc

### DIFF
--- a/pubsub/doc.go
+++ b/pubsub/doc.go
@@ -54,7 +54,9 @@ that is published to the topic will be delivered to all of its subscriptions.
 
 Subsciptions may be created like so:
 
- sub, err := pubsubClient.CreateSubscription(context.Background(), "sub-name", topic, 0, nil)
+ sub, err := pubsubClient.CreateSubscription(context.Background(), "sub-name", pubsub.SubscriptionConfig{
+ 	Topic: topic,
+ })
 
 Messages are then consumed from a subscription via callback.
 


### PR DESCRIPTION
The examples from the function documentation[0] are good, but the introductory one was stale.

[0] https://godoc.org/cloud.google.com/go/pubsub#Client.CreateSubscription
