### PR TITLE
Allow ExpirationTime to be patched onto bigquery tables

### DIFF
--- a/bigquery/service.go
+++ b/bigquery/service.go
@@ -610,9 +610,10 @@ func convertTableReference(tr *bq.TableReference) *Table {
 // patchTableConf contains fields to be patched.
 type patchTableConf struct {
 	// These fields are omitted from the patch operation if nil.
-	Description *string
-	Name        *string
-	Schema      Schema
+	Description    *string
+	Name           *string
+	Schema         Schema
+	ExpirationTime time.Time
 }
 
 func (s *bigqueryService) patchTable(ctx context.Context, projectID, datasetID, tableID string, conf *patchTableConf) (*TableMetadata, error) {
@@ -632,6 +633,10 @@ func (s *bigqueryService) patchTable(ctx context.Context, projectID, datasetID, 
 	if conf.Schema != nil {
 		t.Schema = conf.Schema.asTableSchema()
 		forceSend("Schema")
+	}
+	if !conf.ExpirationTime.IsZero() {
+		t.ExpirationTime = conf.ExpirationTime.UnixNano() / 1e6
+		forceSend("ExpirationTime")
 	}
 	table, err := s.s.Tables.Patch(projectID, datasetID, tableID, t).
 		Context(ctx).

--- a/bigquery/table.go
+++ b/bigquery/table.go
@@ -234,6 +234,7 @@ func (t *Table) Update(ctx context.Context, tm TableMetadataToUpdate) (*TableMet
 		conf.Name = &s
 	}
 	conf.Schema = tm.Schema
+	conf.ExpirationTime = tm.ExpirationTime
 	return t.c.service.patchTable(ctx, t.ProjectID, t.DatasetID, t.TableID, &conf)
 }
 
@@ -250,4 +251,7 @@ type TableMetadataToUpdate struct {
 	// When updating a schema, you can add columns but not remove them.
 	Schema Schema
 	// TODO(jba): support updating the view
+
+	// Set the expiration time for this table
+	ExpirationTime time.Time
 }


### PR DESCRIPTION
This is something I needed to be able to do for a project at work, It would be nice to use the official branch rather than a fork if possible. 

The only thing I'm not 100% on is the `t.ExpirationTime = conf.ExpirationTime.UnixNano() / 1e6` line in `service.go` - It seems to work and we use it daily so hopefully it's correct.