### PR TITLE
Datastore omitempty tag for GeoPoint and time.Time

### DIFF
--- a/datastore/save.go
+++ b/datastore/save.go
@@ -69,7 +69,17 @@ func saveStructProperty(props *[]Property, name string, opts saveOpts, v reflect
 	}
 
 	switch x := v.Interface().(type) {
-	case *Key, time.Time, GeoPoint:
+	case *Key:
+		p.Value = x
+	case GeoPoint:
+		if opts.omitEmpty && (GeoPoint{}) == x {
+			return nil
+		}
+		p.Value = x
+	case time.Time:
+		if opts.omitEmpty && x.IsZero() {
+			return nil
+		}
 		p.Value = x
 	default:
 		switch v.Kind() {


### PR DESCRIPTION
When a entity is saving to datastore and you use `omitempty` tag in `GeoPoint` and `time.Time` it will write a default value, but it is not the intender behaviour so with the extra cases in the switch we make sure `omitempty` works in the intended way