### PR TITLE
bigquery: Add TimePartitioning to QueryConfig

### DIFF
--- a/bigquery/query.go
+++ b/bigquery/query.go
@@ -42,6 +42,10 @@ type QueryConfig struct {
 	// are always of type *ExternalDataConfig.
 	TableDefinitions map[string]ExternalData
 
+	// TimePartitioning specifies time-based partitioning
+	// for the destination table.
+	TimePartitioning *TimePartitioning
+
 	// CreateDisposition specifies the circumstances under which the destination table will be created.
 	// The default is CreateIfNeeded.
 	CreateDisposition TableCreateDisposition
@@ -121,6 +125,7 @@ func (qc *QueryConfig) toBQ() (*bq.JobConfiguration, error) {
 		AllowLargeResults:  qc.AllowLargeResults,
 		Priority:           string(qc.Priority),
 		MaximumBytesBilled: qc.MaxBytesBilled,
+		TimePartitioning:   qc.TimePartitioning.toBQ(),
 	}
 	if len(qc.TableDefinitions) > 0 {
 		qconf.TableDefinitions = make(map[string]bq.ExternalDataConfiguration)
@@ -188,6 +193,7 @@ func bqToQueryConfig(q *bq.JobConfiguration, c *Client) (*QueryConfig, error) {
 		MaxBytesBilled:    qq.MaximumBytesBilled,
 		UseLegacySQL:      qq.UseLegacySql,
 		UseStandardSQL:    !qq.UseLegacySql,
+		TimePartitioning:  bqToTimePartitioning(qq.TimePartitioning),
 	}
 	if len(qq.TableDefinitions) > 0 {
 		qc.TableDefinitions = make(map[string]ExternalData)


### PR DESCRIPTION
Because `QueryConfig` doesn't have `TimePartitioning` field, `bigquery` package can't insert Job which create partitioning table from query.

This PR add `TimePartitioning` field to `QueryConfig`