### PR TITLE
Fix ReadRows() reading bug

### DIFF
--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -148,6 +148,12 @@ func (t *Table) ReadRows(ctx context.Context, arg RowSet, f func(Row) bool, opts
 
 	var prevRowKey string
 	err := gax.Invoke(ctx, func(ctx context.Context) error {
+		if !arg.valid() {
+			// Empty row set, no need to make an API call.
+			// NOTE: we must return early if arg.(type) == RowList because reading an empty RowList from
+			// bigtable returns all rows from that table.
+			return nil
+		}
 		req := &btpb.ReadRowsRequest{
 			TableName:    t.c.fullTableName(t.table),
 			AppProfileId: t.c.appProfile,

--- a/bigtable/bigtable.go
+++ b/bigtable/bigtable.go
@@ -338,7 +338,7 @@ func (r RowRange) retainRowsAfter(lastRowKey string) RowSet {
 }
 
 func (r RowRange) valid() bool {
-	return r.start < r.limit
+	return r.Unbounded() || r.start < r.limit
 }
 
 // RowRangeList is a sequence of RowRanges representing the union of the ranges.


### PR DESCRIPTION
Here are the steps that produce the bug
1) Call table.ReadRow() on some row. table.ReadRow() calls table.ReadRows(RowList{row})
2) The bigtable server returns the row, plus some retryable error. Yes, this really happens.
3) arg = arg.retainRowsAfter(prevRowKey) sets arg to an empty RowList
4) Now the client starts scanning the whole table because table.ReadRows(RowList{}) scans the
   whole table.