### PR TITLE
Modify: Add schema and host to storage.ObjectHandle

### DIFF
--- a/storage/reader.go
+++ b/storage/reader.go
@@ -65,6 +65,15 @@ func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64)
 		Path:     fmt.Sprintf("/%s/%s", o.bucket, o.object),
 		RawQuery: conditionsQuery(o.gen, o.conds),
 	}
+
+	if o.schema != "" {
+		u.Scheme = o.schema
+	}
+
+	if o.host != "" {
+		u.Host = o.host
+	}
+
 	verb := "GET"
 	if length == 0 {
 		verb = "HEAD"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -316,6 +316,8 @@ func SignedURL(bucket, name string, opts *SignedURLOptions) (string, error) {
 // Use BucketHandle.Object to get a handle.
 type ObjectHandle struct {
 	c              *Client
+	schema string
+	host string
 	bucket         string
 	object         string
 	acl            ACLHandle
@@ -324,6 +326,14 @@ type ObjectHandle struct {
 	encryptionKey  []byte // AES-256 key
 	userProject    string // for requester-pays buckets
 	readCompressed bool   // Accept-Encoding: gzip
+}
+
+// Endpoint changes the end point
+func (o *ObjectHandle) Endpoint(schema, host string) *ObjectHandle {
+	o2 := *o
+	o2.schema = schema
+	o2.host = host
+	return &o2
 }
 
 // ACL provides access to the object's access control list.


### PR DESCRIPTION
## Issue 

https://github.com/GoogleCloudPlatform/google-cloud-go/issues/964

## Changes

- Add schema and host to storage.ObjectHandle
- Add Endpoint change method to storage.ObjectHandle