### PR TITLE
add TransactionDelta struct

### DIFF
--- a/firestore/transaction.go
+++ b/firestore/transaction.go
@@ -26,6 +26,52 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type TransactionDelta struct {
+	tx *Transaction
+	delta []func() error
+}
+
+func (writes *TransactionDelta) Create(doc *DocumentRef, d interface{}) {
+	writes.delta = append(writes.delta, func() error {
+		return writes.tx.Create(doc, d)
+	})
+}
+
+func (writes *TransactionDelta) Set(doc *DocumentRef, d interface{}, opts... SetOption) {
+	writes.delta = append(writes.delta, func() error {
+		return writes.tx.Set(doc, d, opts...)
+	})
+}
+
+func (writes *TransactionDelta) Update(doc *DocumentRef, u []Update, precondition... Precondition) {
+	writes.delta = append(writes.delta, func() error {
+		return writes.tx.Update(doc, u, precondition...)
+	})
+}
+
+func (writes *TransactionDelta) Delete(doc *DocumentRef, precondition... Precondition) {
+	writes.delta = append(writes.delta, func() error {
+		return writes.tx.Delete(doc, precondition...)
+	})
+}
+
+func (writes *TransactionDelta) Apply() error {
+	for _, fn := range writes.delta {
+		err := fn()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewTransactionDelta(tx *Transaction) *TransactionDelta {
+	return &TransactionDelta{
+		tx: tx,
+		delta: []func() error{},
+	}
+}
+
 // Transaction represents a Firestore transaction.
 type Transaction struct {
 	c              *Client


### PR DESCRIPTION
This PR provides a convenient way to avoid `read-after-write` errors in datastore transactions.
Having delta one can store every change inside it and in the end of transaction call `td.Apply()`
Example:
```
err := client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
    td := firestore.NewTransactionDelta(tx)
    // some reads
    td.Set(docRef, data)
    // some more reads
    td.Update(docRef, updates)
    return td.Apply()
})
```