### PR TITLE
Support custom grpc dial option for client connecting to datastore emulator

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -59,11 +59,11 @@ func NewClient(ctx context.Context, projectID string, opts ...option.ClientOptio
 	// https://cloud.google.com/datastore/docs/tools/datastore-emulator
 	// If the emulator is available, dial it directly (and don't pass any credentials).
 	if addr := os.Getenv("DATASTORE_EMULATOR_HOST"); addr != "" {
-		conn, err := grpc.Dial(addr, grpc.WithInsecure())
-		if err != nil {
-			return nil, fmt.Errorf("grpc.Dial: %v", err)
+		o = []option.ClientOption{
+			option.WithEndpoint(addr),
+			option.WithoutAuthentication(),
+			option.WithGRPCDialOption(grpc.WithInsecure()),
 		}
-		o = []option.ClientOption{option.WithGRPCConn(conn)}
 	} else {
 		o = []option.ClientOption{
 			option.WithEndpoint(prodAddr),


### PR DESCRIPTION
I was trying to use `rpcreplay` and `datastore emulator` together.  Found that `rpcreplay` could not intercept the grpc calls.

After looking into `datastore` package, it seems `NewClient` function dial to datastore emulator directly so extra grpc dial options in `opts` would not work.

This commit make `NewClient` dial later in the `gtransport.Dial` function to fix the issue.