### PR TITLE
Updates formatting in logging docs

### DIFF
--- a/logging/doc.go
+++ b/logging/doc.go
@@ -122,8 +122,8 @@ project, and have the same MonitoredResouce type and labels.
 - Parent entries must have HTTPRequest.Request populated. (Strictly speaking, only the URL is necessary.)
 
 - A child entry's timestamp must be within the time interval covered by the parent request (i.e., older
-  than parent.Timestamp, and newer than parent.Timestamp - parent.HTTPRequest.Latency, assuming the
-  parent timestamp marks the end of the request.
+than parent.Timestamp, and newer than parent.Timestamp - parent.HTTPRequest.Latency, assuming the
+parent timestamp marks the end of the request.
 
 - The trace field must be populated in all of the entries and match exactly.
 


### PR DESCRIPTION
The indents caused the block to be formatted as a code block.