### PR TITLE
firestore: Fix nilpointer in QuerySnapshotIterator

### DIFF
--- a/firestore/query.go
+++ b/firestore/query.go
@@ -749,7 +749,9 @@ func (it *QuerySnapshotIterator) Next() (*QuerySnapshot, error) {
 // a QuerySnapshotIterator, to free up resources. It is not safe to call Stop
 // concurrently with Next.
 func (it *QuerySnapshotIterator) Stop() {
-	it.ws.stop()
+	if it.ws != nil {
+		it.ws.stop()	
+	}
 }
 
 // A QuerySnapshot is a snapshot of query results. It is returned by


### PR DESCRIPTION
When your QuerySnapshotIterator is in error state, it might be that 
its watchStream is nil. So here i check whether it's nil before trying to
stop it.